### PR TITLE
merge metaclip2

### DIFF
--- a/inference_demo_simple.py
+++ b/inference_demo_simple.py
@@ -36,17 +36,17 @@ class SimpleKeypointInference:
         if model_type == 'bedsheet':
             self.model_path = 'models/meta_clip_style_bedsheet_post_original'
             self.model_config = {
-                'lora_r': 16, 'lora_alpha': 32, 'image_size': 256, 'use_text_prior': True
+                'lora_r': 16, 'lora_alpha': 32, 'image_size': 560, 'use_text_prior': True
             }
         elif model_type == 'mattress':  # mattress
             self.model_path = 'models/meta_clip_style_mattress_post_original'
             self.model_config = {
-                'lora_r': 16, 'lora_alpha': 32, 'image_size': 256, 'use_text_prior': True
+                'lora_r': 16, 'lora_alpha': 32, 'image_size': 560, 'use_text_prior': True
             }
         elif model_type == 'fitted_sheet_inverse':  # fitted_sheet
             self.model_path = 'models/meta_clip_style_fitted_sheet_inverse_post_original'
             self.model_config = {
-                'lora_r': 16, 'lora_alpha': 32, 'image_size': 256, 'use_text_prior': True
+                'lora_r': 16, 'lora_alpha': 32, 'image_size': 560, 'use_text_prior': True
             }
         
         self.model = None
@@ -59,7 +59,7 @@ class SimpleKeypointInference:
         
         # Create model with same config as training
         self.model = ClipHeatmapModel(
-            model_name='facebook/metaclip-b16-fullcc2.5b',
+            model_name='facebook/metaclip-2-worldwide-l14',
             image_size=self.model_config['image_size'],
             use_lora=True,
             lora_r=self.model_config['lora_r'],

--- a/meta_clip_style_bedsheet_training.py
+++ b/meta_clip_style_bedsheet_training.py
@@ -36,6 +36,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "src"))
 # Import CLIP model and utilities
 from src.models import ClipHeatmapModel, create_clip_heatmap_model
 from src.utils.model_utils import kl_heatmap_loss, batch_gaussian_blur, normalize_heatmaps
+from src.utils.torch_memory import free_torch_memory
 from shared.functions import get_keypoints_for_image, resize_image_and_keypoints
 
 # Import simple augmentation
@@ -52,7 +53,7 @@ except ImportError:
 # Default configuration for post-training
 DEFAULT_CONFIG = {
     # Model configuration
-    "model_name": "facebook/metaclip-b16-fullcc2.5b",  # Meta CLIP model
+    "model_name": "facebook/metaclip-2-worldwide-l14",  # MetaCLIP2 L/14 (patch14 => use image_size=560)
     "use_original_metaclip": False,  # Set to True to use original Meta CLIP instead of pre-trained
     "ensure_equal_params": True,  # Ensure both models have identical trainable parameters
     "output_dir": "models/meta_clip_style_bedsheet_post",
@@ -67,10 +68,10 @@ DEFAULT_CONFIG = {
     ],
     "yolo_model_path": "models/yolo_finetuned/best_2.pt",
     "allowed_classes": [3],  # bedsheet class
-    "image_size": 256,
+    "image_size": 560,
     
     # Training configuration
-    "batch_size": 4,
+    "batch_size": 2,
     "num_epochs": 20,
     "learning_rate": 3e-4,  # Match original training LR for fair comparison
     "weight_decay": 1e-4,
@@ -757,6 +758,24 @@ def compare_models_equal_params(config: Dict[str, Any]) -> bool:
     
     model_original = load_pretrained_meta_clip_model(config_original)
     params_original = sum(p.numel() for p in model_original.parameters() if p.requires_grad)
+    original_trainable_names = {
+        name for name, param in model_original.named_parameters() if param.requires_grad
+    }
+    original_out_shape: Optional[torch.Size] = None
+    try:
+        dummy_size = int(config.get("image_size", 560))
+        dummy_input = torch.randn(1, 3, dummy_size, dummy_size)
+        model_original.eval()
+        with torch.no_grad():
+            output_original = model_original(dummy_input)
+        original_out_shape = output_original.shape
+        print(f"✓ Original model forward ok: {original_out_shape}")
+    except Exception as e:
+        print(f"✗ Original model forward pass failed: {e}")
+        success = False
+
+    model_original = None
+    free_torch_memory(move_modules_to_cpu=True)
     
     # Test pre-trained model
     print("\n2. Creating Pre-trained Meta CLIP Model:")
@@ -767,6 +786,24 @@ def compare_models_equal_params(config: Dict[str, Any]) -> bool:
     
     model_pretrained = load_pretrained_meta_clip_model(config_pretrained)
     params_pretrained = sum(p.numel() for p in model_pretrained.parameters() if p.requires_grad)
+    pretrained_trainable_names = {
+        name for name, param in model_pretrained.named_parameters() if param.requires_grad
+    }
+    pretrained_out_shape: Optional[torch.Size] = None
+    try:
+        dummy_size = int(config.get("image_size", 560))
+        dummy_input = torch.randn(1, 3, dummy_size, dummy_size)
+        model_pretrained.eval()
+        with torch.no_grad():
+            output_pretrained = model_pretrained(dummy_input)
+        pretrained_out_shape = output_pretrained.shape
+        print(f"✓ Pre-trained model forward ok: {pretrained_out_shape}")
+    except Exception as e:
+        print(f"✗ Pre-trained model forward pass failed: {e}")
+        success = False
+
+    model_pretrained = None
+    free_torch_memory(move_modules_to_cpu=True)
     
     # Final comparison
     print("\n3. Final Parameter Comparison:")
@@ -786,17 +823,6 @@ def compare_models_equal_params(config: Dict[str, Any]) -> bool:
     # Verify exact parameter matching
     print("\n4. Verifying Exact Parameter Matching:")
     print("-" * 50)
-    
-    # Get trainable parameter names from both models
-    original_trainable_names = set()
-    for name, param in model_original.named_parameters():
-        if param.requires_grad:
-            original_trainable_names.add(name)
-    
-    pretrained_trainable_names = set()
-    for name, param in model_pretrained.named_parameters():
-        if param.requires_grad:
-            pretrained_trainable_names.add(name)
     
     print(f"Original model trainable parameter groups: {len(original_trainable_names)}")
     print(f"Pre-trained model trainable parameter groups: {len(pretrained_trainable_names)}")
@@ -830,31 +856,16 @@ def compare_models_equal_params(config: Dict[str, Any]) -> bool:
         print("  The key is that both models have identical trainable parameter counts.")
         exact_match = False
     
-    # Test forward pass
+    # Test forward pass shapes (captured above)
     print("\n5. Testing Forward Pass:")
     print("-" * 50)
-    
-    try:
-        dummy_input = torch.randn(1, 3, 256, 256)
-        
-        model_original.eval()
-        with torch.no_grad():
-            output_original = model_original(dummy_input)
-        print(f"✓ Original model: {output_original.shape}")
-        
-        model_pretrained.eval()
-        with torch.no_grad():
-            output_pretrained = model_pretrained(dummy_input)
-        print(f"✓ Pre-trained model: {output_pretrained.shape}")
-        
-        if output_original.shape == output_pretrained.shape:
+    if original_out_shape is not None and pretrained_out_shape is not None:
+        if original_out_shape == pretrained_out_shape:
             print("✅ Both models produce identical output shapes")
         else:
-            print(f"⚠️  Output shape mismatch")
-            
-    except Exception as e:
-        print(f"✗ Forward pass failed: {e}")
-        success = False
+            print(f"⚠️  Output shape mismatch: {original_out_shape} vs {pretrained_out_shape}")
+    else:
+        print("⚠️  Could not compare output shapes (at least one forward pass failed)")
     
     print("\n" + "=" * 80)
     if success and exact_match:
@@ -976,14 +987,18 @@ def main_meta_clip_post_training_pipeline(config: Dict[str, Any]) -> Tuple[ClipH
     # Train model
     trained_model, history = train_meta_clip_post_model(model, train_loader, val_loader, config)
     
-    # Load the trained model from saved checkpoint for evaluation
-    print("\n=== Loading Trained Model from Checkpoint ===")
-    reloaded_model = load_pretrained_meta_clip_model(config)
-    
     # Load the trained weights
     checkpoint_path = os.path.join(config["output_dir"], "complete_model.pth")
     if os.path.exists(checkpoint_path):
         print(f"Loading trained weights from: {checkpoint_path}")
+        # Free the in-memory trained model before reloading to avoid OOM (two models on GPU).
+        model = None
+        trained_model = None
+        free_torch_memory(move_modules_to_cpu=True)
+
+        # Load the trained model from saved checkpoint for evaluation
+        print("\n=== Loading Trained Model from Checkpoint ===")
+        reloaded_model = load_pretrained_meta_clip_model(config)
         checkpoint = torch.load(checkpoint_path, map_location='cpu')
         # The checkpoint is saved directly as model state dict, not wrapped
         reloaded_model.load_state_dict(checkpoint)
@@ -1004,7 +1019,8 @@ def main_meta_clip_post_training_pipeline(config: Dict[str, Any]) -> Tuple[ClipH
     print(f"Model saved to: {config['output_dir']}")
     print(f"Results saved to: {config['results_dir']}")
     
-    return trained_model, history
+    # Return the model actually used for evaluation (reloaded if available).
+    return reloaded_model, history
 
 if __name__ == "__main__":
     import argparse

--- a/meta_clip_style_cloth_training.py
+++ b/meta_clip_style_cloth_training.py
@@ -355,12 +355,12 @@ def train_meta_clip_heatmap():
 
     # Meta CLIP model configuration
     config = {
-        'model_name': 'facebook/metaclip-b16-fullcc2.5b',  # Meta CLIP model
+        'model_name': 'facebook/metaclip-2-worldwide-l14',  # MetaCLIP2 L/14 (patch14 => use image_size=560)
         'data_dir': 'cloth_data_gen/bedsheet_dataset_3000',
         'output_dir': 'models/meta_clip_style_cloth',
-        'image_size': 256,
+        'image_size': 560,
         'auto_image_size': True,
-        'batch_size': 4,
+        'batch_size': 2,
         'num_epochs': 20,  # Increased epochs for larger dataset
         'learning_rate': 3e-4,
         'weight_decay': 1e-4,

--- a/meta_clip_style_fitted_sheet_inverse_training.py
+++ b/meta_clip_style_fitted_sheet_inverse_training.py
@@ -36,6 +36,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "src"))
 # Import CLIP model and utilities
 from src.models import ClipHeatmapModel, create_clip_heatmap_model
 from src.utils.model_utils import kl_heatmap_loss, batch_gaussian_blur, normalize_heatmaps
+from src.utils.torch_memory import free_torch_memory
 from shared.functions import get_keypoints_for_image, resize_image_and_keypoints
 
 # TensorRT utilities
@@ -49,7 +50,7 @@ except ImportError:
 # Default configuration for post-training
 DEFAULT_CONFIG = {
     # Model configuration
-    "model_name": "facebook/metaclip-b16-fullcc2.5b",  # Meta CLIP model
+    "model_name": "facebook/metaclip-2-worldwide-l14",  # MetaCLIP2 L/14 (patch14 => use image_size=560)
     "use_original_metaclip": False,  # Set to True to use original Meta CLIP instead of pre-trained
     "ensure_equal_params": True,  # Ensure both models have identical trainable parameters
     "output_dir": "models/meta_clip_style_fitted_sheet_inverse_post",
@@ -65,10 +66,10 @@ DEFAULT_CONFIG = {
     ],
     "yolo_model_path": "models/yolo_finetuned/sheet_without_plastic.v11i.yolov11/runs/segment/train/weights/best.pt",
     "allowed_classes": [1],  # fitted_sheet class
-    "image_size": 256,
+    "image_size": 560,
     
     # Training configuration
-    "batch_size": 4,
+    "batch_size": 2,
     "num_epochs": 20,
     "learning_rate": 3e-4,  # Match original training LR for fair comparison
     "weight_decay": 1e-4,
@@ -753,6 +754,25 @@ def compare_models_equal_params(config: Dict[str, Any]) -> bool:
     
     model_original = load_pretrained_meta_clip_model(config_original)
     params_original = sum(p.numel() for p in model_original.parameters() if p.requires_grad)
+    original_trainable_names = {
+        name for name, param in model_original.named_parameters() if param.requires_grad
+    }
+    original_out_shape: Optional[torch.Size] = None
+    try:
+        dummy_size = int(config.get("image_size", 560))
+        dummy_input = torch.randn(1, 3, dummy_size, dummy_size)
+        model_original.eval()
+        with torch.no_grad():
+            output_original = model_original(dummy_input)
+        original_out_shape = output_original.shape
+        print(f"✓ Original model forward ok: {original_out_shape}")
+    except Exception as e:
+        print(f"✗ Original model forward pass failed: {e}")
+        success = False
+
+    # Free original before loading pre-trained to avoid temporary two-model OOM.
+    model_original = None
+    free_torch_memory(move_modules_to_cpu=True)
     
     # Test pre-trained model
     print("\n2. Creating Pre-trained Meta CLIP Model:")
@@ -763,6 +783,24 @@ def compare_models_equal_params(config: Dict[str, Any]) -> bool:
     
     model_pretrained = load_pretrained_meta_clip_model(config_pretrained)
     params_pretrained = sum(p.numel() for p in model_pretrained.parameters() if p.requires_grad)
+    pretrained_trainable_names = {
+        name for name, param in model_pretrained.named_parameters() if param.requires_grad
+    }
+    pretrained_out_shape: Optional[torch.Size] = None
+    try:
+        dummy_size = int(config.get("image_size", 560))
+        dummy_input = torch.randn(1, 3, dummy_size, dummy_size)
+        model_pretrained.eval()
+        with torch.no_grad():
+            output_pretrained = model_pretrained(dummy_input)
+        pretrained_out_shape = output_pretrained.shape
+        print(f"✓ Pre-trained model forward ok: {pretrained_out_shape}")
+    except Exception as e:
+        print(f"✗ Pre-trained model forward pass failed: {e}")
+        success = False
+
+    model_pretrained = None
+    free_torch_memory(move_modules_to_cpu=True)
     
     # Final comparison
     print("\n3. Final Parameter Comparison:")
@@ -782,17 +820,6 @@ def compare_models_equal_params(config: Dict[str, Any]) -> bool:
     # Verify exact parameter matching
     print("\n4. Verifying Exact Parameter Matching:")
     print("-" * 50)
-    
-    # Get trainable parameter names from both models
-    original_trainable_names = set()
-    for name, param in model_original.named_parameters():
-        if param.requires_grad:
-            original_trainable_names.add(name)
-    
-    pretrained_trainable_names = set()
-    for name, param in model_pretrained.named_parameters():
-        if param.requires_grad:
-            pretrained_trainable_names.add(name)
     
     print(f"Original model trainable parameter groups: {len(original_trainable_names)}")
     print(f"Pre-trained model trainable parameter groups: {len(pretrained_trainable_names)}")
@@ -826,31 +853,16 @@ def compare_models_equal_params(config: Dict[str, Any]) -> bool:
         print("  The key is that both models have identical trainable parameter counts.")
         exact_match = False
     
-    # Test forward pass
+    # Test forward pass shapes (captured above)
     print("\n5. Testing Forward Pass:")
     print("-" * 50)
-    
-    try:
-        dummy_input = torch.randn(1, 3, 256, 256)
-        
-        model_original.eval()
-        with torch.no_grad():
-            output_original = model_original(dummy_input)
-        print(f"✓ Original model: {output_original.shape}")
-        
-        model_pretrained.eval()
-        with torch.no_grad():
-            output_pretrained = model_pretrained(dummy_input)
-        print(f"✓ Pre-trained model: {output_pretrained.shape}")
-        
-        if output_original.shape == output_pretrained.shape:
+    if original_out_shape is not None and pretrained_out_shape is not None:
+        if original_out_shape == pretrained_out_shape:
             print("✅ Both models produce identical output shapes")
         else:
-            print(f"⚠️  Output shape mismatch")
-            
-    except Exception as e:
-        print(f"✗ Forward pass failed: {e}")
-        success = False
+            print(f"⚠️  Output shape mismatch: {original_out_shape} vs {pretrained_out_shape}")
+    else:
+        print("⚠️  Could not compare output shapes (at least one forward pass failed)")
     
     print("\n" + "=" * 80)
     if success and exact_match:
@@ -966,14 +978,18 @@ def main_meta_clip_post_training_pipeline(config: Dict[str, Any]) -> Tuple[ClipH
     # Train model
     trained_model, history = train_meta_clip_post_model(model, train_loader, val_loader, config)
     
-    # Load the trained model from saved checkpoint for evaluation
-    print("\n=== Loading Trained Model from Checkpoint ===")
-    reloaded_model = load_pretrained_meta_clip_model(config)
-    
     # Load the trained weights
     checkpoint_path = os.path.join(config["output_dir"], "complete_model.pth")
     if os.path.exists(checkpoint_path):
         print(f"Loading trained weights from: {checkpoint_path}")
+        # Free the in-memory trained model before reloading to avoid OOM (two models on GPU).
+        model = None
+        trained_model = None
+        free_torch_memory(move_modules_to_cpu=True)
+
+        # Load the trained model from saved checkpoint for evaluation
+        print("\n=== Loading Trained Model from Checkpoint ===")
+        reloaded_model = load_pretrained_meta_clip_model(config)
         checkpoint = torch.load(checkpoint_path, map_location='cpu')
         # The checkpoint is saved directly as model state dict, not wrapped
         reloaded_model.load_state_dict(checkpoint)
@@ -994,7 +1010,8 @@ def main_meta_clip_post_training_pipeline(config: Dict[str, Any]) -> Tuple[ClipH
     print(f"Model saved to: {config['output_dir']}")
     print(f"Results saved to: {config['results_dir']}")
     
-    return trained_model, history
+    # Return the model actually used for evaluation (reloaded if available).
+    return reloaded_model, history
 
 if __name__ == "__main__":
     import argparse

--- a/meta_clip_style_fitted_sheet_training.py
+++ b/meta_clip_style_fitted_sheet_training.py
@@ -36,6 +36,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "src"))
 # Import CLIP model and utilities
 from src.models import ClipHeatmapModel, create_clip_heatmap_model
 from src.utils.model_utils import kl_heatmap_loss, batch_gaussian_blur, normalize_heatmaps
+from src.utils.torch_memory import free_torch_memory
 from shared.functions import get_keypoints_for_image, resize_image_and_keypoints
 
 # Import simple augmentation
@@ -52,7 +53,7 @@ except ImportError:
 # Default configuration for post-training
 DEFAULT_CONFIG = {
     # Model configuration
-    "model_name": "facebook/metaclip-b16-fullcc2.5b",  # Meta CLIP model
+    "model_name": "facebook/metaclip-2-worldwide-l14",  # MetaCLIP2 L/14 (patch14 => use image_size=560)
     "use_original_metaclip": False,  # Set to True to use original Meta CLIP instead of pre-trained
     "ensure_equal_params": True,  # Ensure both models have identical trainable parameters
     "output_dir": "models/meta_clip_style_fitted_sheet_post",
@@ -68,10 +69,10 @@ DEFAULT_CONFIG = {
     ],
     "yolo_model_path": "models/yolo_finetuned/sheet_without_plastic.v11i.yolov11/runs/segment/train/weights/best.pt",
     "allowed_classes": [1],  # fitted_sheet class
-    "image_size": 256,
+    "image_size": 560,
     
     # Training configuration
-    "batch_size": 4,
+    "batch_size": 2,
     "num_epochs": 20,
     "learning_rate": 3e-4,  # Match original training LR for fair comparison
     "weight_decay": 1e-4,
@@ -757,6 +758,24 @@ def compare_models_equal_params(config: Dict[str, Any]) -> bool:
     
     model_original = load_pretrained_meta_clip_model(config_original)
     params_original = sum(p.numel() for p in model_original.parameters() if p.requires_grad)
+    original_trainable_names = {
+        name for name, param in model_original.named_parameters() if param.requires_grad
+    }
+    original_out_shape: Optional[torch.Size] = None
+    try:
+        dummy_size = int(config.get("image_size", 560))
+        dummy_input = torch.randn(1, 3, dummy_size, dummy_size)
+        model_original.eval()
+        with torch.no_grad():
+            output_original = model_original(dummy_input)
+        original_out_shape = output_original.shape
+        print(f"✓ Original model forward ok: {original_out_shape}")
+    except Exception as e:
+        print(f"✗ Original model forward pass failed: {e}")
+        success = False
+
+    model_original = None
+    free_torch_memory(move_modules_to_cpu=True)
     
     # Test pre-trained model
     print("\n2. Creating Pre-trained Meta CLIP Model:")
@@ -767,6 +786,24 @@ def compare_models_equal_params(config: Dict[str, Any]) -> bool:
     
     model_pretrained = load_pretrained_meta_clip_model(config_pretrained)
     params_pretrained = sum(p.numel() for p in model_pretrained.parameters() if p.requires_grad)
+    pretrained_trainable_names = {
+        name for name, param in model_pretrained.named_parameters() if param.requires_grad
+    }
+    pretrained_out_shape: Optional[torch.Size] = None
+    try:
+        dummy_size = int(config.get("image_size", 560))
+        dummy_input = torch.randn(1, 3, dummy_size, dummy_size)
+        model_pretrained.eval()
+        with torch.no_grad():
+            output_pretrained = model_pretrained(dummy_input)
+        pretrained_out_shape = output_pretrained.shape
+        print(f"✓ Pre-trained model forward ok: {pretrained_out_shape}")
+    except Exception as e:
+        print(f"✗ Pre-trained model forward pass failed: {e}")
+        success = False
+
+    model_pretrained = None
+    free_torch_memory(move_modules_to_cpu=True)
     
     # Final comparison
     print("\n3. Final Parameter Comparison:")
@@ -786,17 +823,6 @@ def compare_models_equal_params(config: Dict[str, Any]) -> bool:
     # Verify exact parameter matching
     print("\n4. Verifying Exact Parameter Matching:")
     print("-" * 50)
-    
-    # Get trainable parameter names from both models
-    original_trainable_names = set()
-    for name, param in model_original.named_parameters():
-        if param.requires_grad:
-            original_trainable_names.add(name)
-    
-    pretrained_trainable_names = set()
-    for name, param in model_pretrained.named_parameters():
-        if param.requires_grad:
-            pretrained_trainable_names.add(name)
     
     print(f"Original model trainable parameter groups: {len(original_trainable_names)}")
     print(f"Pre-trained model trainable parameter groups: {len(pretrained_trainable_names)}")
@@ -830,31 +856,16 @@ def compare_models_equal_params(config: Dict[str, Any]) -> bool:
         print("  The key is that both models have identical trainable parameter counts.")
         exact_match = False
     
-    # Test forward pass
+    # Test forward pass shapes (captured above)
     print("\n5. Testing Forward Pass:")
     print("-" * 50)
-    
-    try:
-        dummy_input = torch.randn(1, 3, 256, 256)
-        
-        model_original.eval()
-        with torch.no_grad():
-            output_original = model_original(dummy_input)
-        print(f"✓ Original model: {output_original.shape}")
-        
-        model_pretrained.eval()
-        with torch.no_grad():
-            output_pretrained = model_pretrained(dummy_input)
-        print(f"✓ Pre-trained model: {output_pretrained.shape}")
-        
-        if output_original.shape == output_pretrained.shape:
+    if original_out_shape is not None and pretrained_out_shape is not None:
+        if original_out_shape == pretrained_out_shape:
             print("✅ Both models produce identical output shapes")
         else:
-            print(f"⚠️  Output shape mismatch")
-            
-    except Exception as e:
-        print(f"✗ Forward pass failed: {e}")
-        success = False
+            print(f"⚠️  Output shape mismatch: {original_out_shape} vs {pretrained_out_shape}")
+    else:
+        print("⚠️  Could not compare output shapes (at least one forward pass failed)")
     
     print("\n" + "=" * 80)
     if success and exact_match:
@@ -977,14 +988,18 @@ def main_meta_clip_post_training_pipeline(config: Dict[str, Any]) -> Tuple[ClipH
     # Train model
     trained_model, history = train_meta_clip_post_model(model, train_loader, val_loader, config)
     
-    # Load the trained model from saved checkpoint for evaluation
-    print("\n=== Loading Trained Model from Checkpoint ===")
-    reloaded_model = load_pretrained_meta_clip_model(config)
-    
     # Load the trained weights
     checkpoint_path = os.path.join(config["output_dir"], "complete_model.pth")
     if os.path.exists(checkpoint_path):
         print(f"Loading trained weights from: {checkpoint_path}")
+        # Free the in-memory trained model before reloading to avoid OOM (two models on GPU).
+        model = None
+        trained_model = None
+        free_torch_memory(move_modules_to_cpu=True)
+
+        # Load the trained model from saved checkpoint for evaluation
+        print("\n=== Loading Trained Model from Checkpoint ===")
+        reloaded_model = load_pretrained_meta_clip_model(config)
         checkpoint = torch.load(checkpoint_path, map_location='cpu')
         # The checkpoint is saved directly as model state dict, not wrapped
         reloaded_model.load_state_dict(checkpoint)
@@ -1005,7 +1020,8 @@ def main_meta_clip_post_training_pipeline(config: Dict[str, Any]) -> Tuple[ClipH
     print(f"Model saved to: {config['output_dir']}")
     print(f"Results saved to: {config['results_dir']}")
     
-    return trained_model, history
+    # Return the model actually used for evaluation (reloaded if available).
+    return reloaded_model, history
 
 if __name__ == "__main__":
     import argparse

--- a/meta_clip_style_mattress_training.py
+++ b/meta_clip_style_mattress_training.py
@@ -36,6 +36,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "src"))
 # Import CLIP model and utilities
 from src.models import ClipHeatmapModel, create_clip_heatmap_model
 from src.utils.model_utils import kl_heatmap_loss, batch_gaussian_blur, normalize_heatmaps
+from src.utils.torch_memory import free_torch_memory
 from shared.functions import get_keypoints_for_image, resize_image_and_keypoints
 
 # Import simple augmentation
@@ -52,7 +53,7 @@ except ImportError:
 # Default configuration for post-training
 DEFAULT_CONFIG = {
     # Model configuration
-    "model_name": "facebook/metaclip-b16-fullcc2.5b",  # Meta CLIP model
+    "model_name": "facebook/metaclip-2-worldwide-l14",  # MetaCLIP2 L/14 (patch14 => use image_size=560)
     "use_original_metaclip": False,  # Set to True to use original Meta CLIP instead of pre-trained
     "ensure_equal_params": True,  # Ensure both models have identical trainable parameters
     "output_dir": "models/meta_clip_style_mattress_post",
@@ -67,10 +68,10 @@ DEFAULT_CONFIG = {
     ],
     "yolo_model_path": "models/yolo_finetuned/sheet_without_plastic.v11i.yolov11/runs/segment/train/weights/best.pt",
     "allowed_classes": [0,1,2,3],  # mattress class
-    "image_size": 256,
+    "image_size": 560,
     
     # Training configuration
-    "batch_size": 4,
+    "batch_size": 2,
     "num_epochs": 20,
     "learning_rate": 3e-4,  # Match original training LR for fair comparison
     "weight_decay": 1e-4,
@@ -755,6 +756,24 @@ def compare_models_equal_params(config: Dict[str, Any]) -> bool:
     
     model_original = load_pretrained_meta_clip_model(config_original)
     params_original = sum(p.numel() for p in model_original.parameters() if p.requires_grad)
+    original_trainable_names = {
+        name for name, param in model_original.named_parameters() if param.requires_grad
+    }
+    original_out_shape: Optional[torch.Size] = None
+    try:
+        dummy_size = int(config.get("image_size", 560))
+        dummy_input = torch.randn(1, 3, dummy_size, dummy_size)
+        model_original.eval()
+        with torch.no_grad():
+            output_original = model_original(dummy_input)
+        original_out_shape = output_original.shape
+        print(f"✓ Original model forward ok: {original_out_shape}")
+    except Exception as e:
+        print(f"✗ Original model forward pass failed: {e}")
+        success = False
+
+    model_original = None
+    free_torch_memory(move_modules_to_cpu=True)
     
     # Test pre-trained model
     print("\n2. Creating Pre-trained Meta CLIP Model:")
@@ -765,6 +784,24 @@ def compare_models_equal_params(config: Dict[str, Any]) -> bool:
     
     model_pretrained = load_pretrained_meta_clip_model(config_pretrained)
     params_pretrained = sum(p.numel() for p in model_pretrained.parameters() if p.requires_grad)
+    pretrained_trainable_names = {
+        name for name, param in model_pretrained.named_parameters() if param.requires_grad
+    }
+    pretrained_out_shape: Optional[torch.Size] = None
+    try:
+        dummy_size = int(config.get("image_size", 560))
+        dummy_input = torch.randn(1, 3, dummy_size, dummy_size)
+        model_pretrained.eval()
+        with torch.no_grad():
+            output_pretrained = model_pretrained(dummy_input)
+        pretrained_out_shape = output_pretrained.shape
+        print(f"✓ Pre-trained model forward ok: {pretrained_out_shape}")
+    except Exception as e:
+        print(f"✗ Pre-trained model forward pass failed: {e}")
+        success = False
+
+    model_pretrained = None
+    free_torch_memory(move_modules_to_cpu=True)
     
     # Final comparison
     print("\n3. Final Parameter Comparison:")
@@ -784,17 +821,6 @@ def compare_models_equal_params(config: Dict[str, Any]) -> bool:
     # Verify exact parameter matching
     print("\n4. Verifying Exact Parameter Matching:")
     print("-" * 50)
-    
-    # Get trainable parameter names from both models
-    original_trainable_names = set()
-    for name, param in model_original.named_parameters():
-        if param.requires_grad:
-            original_trainable_names.add(name)
-    
-    pretrained_trainable_names = set()
-    for name, param in model_pretrained.named_parameters():
-        if param.requires_grad:
-            pretrained_trainable_names.add(name)
     
     print(f"Original model trainable parameter groups: {len(original_trainable_names)}")
     print(f"Pre-trained model trainable parameter groups: {len(pretrained_trainable_names)}")
@@ -828,31 +854,16 @@ def compare_models_equal_params(config: Dict[str, Any]) -> bool:
         print("  The key is that both models have identical trainable parameter counts.")
         exact_match = False
     
-    # Test forward pass
+    # Test forward pass shapes (captured above)
     print("\n5. Testing Forward Pass:")
     print("-" * 50)
-    
-    try:
-        dummy_input = torch.randn(1, 3, 256, 256)
-        
-        model_original.eval()
-        with torch.no_grad():
-            output_original = model_original(dummy_input)
-        print(f"✓ Original model: {output_original.shape}")
-        
-        model_pretrained.eval()
-        with torch.no_grad():
-            output_pretrained = model_pretrained(dummy_input)
-        print(f"✓ Pre-trained model: {output_pretrained.shape}")
-        
-        if output_original.shape == output_pretrained.shape:
+    if original_out_shape is not None and pretrained_out_shape is not None:
+        if original_out_shape == pretrained_out_shape:
             print("✅ Both models produce identical output shapes")
         else:
-            print(f"⚠️  Output shape mismatch")
-            
-    except Exception as e:
-        print(f"✗ Forward pass failed: {e}")
-        success = False
+            print(f"⚠️  Output shape mismatch: {original_out_shape} vs {pretrained_out_shape}")
+    else:
+        print("⚠️  Could not compare output shapes (at least one forward pass failed)")
     
     print("\n" + "=" * 80)
     if success and exact_match:
@@ -974,15 +985,19 @@ def main_meta_clip_post_training_pipeline(config: Dict[str, Any]) -> Tuple[ClipH
     # Train model
     trained_model, history = train_meta_clip_post_model(model, train_loader, val_loader, config)
     
-    # Load the trained model from saved checkpoint for evaluation
-    print("\n=== Loading Trained Model from Checkpoint ===")
-    reloaded_model = load_pretrained_meta_clip_model(config)
-    
     # Load the trained weights
     checkpoint_path = os.path.join(config["output_dir"], "complete_model.pth")
     print("complete model path:", checkpoint_path)
     if os.path.exists(checkpoint_path):
         print(f"Loading trained weights from: {checkpoint_path}")
+        # Free the in-memory trained model before reloading to avoid OOM (two models on GPU).
+        model = None
+        trained_model = None
+        free_torch_memory(move_modules_to_cpu=True)
+
+        # Load the trained model from saved checkpoint for evaluation
+        print("\n=== Loading Trained Model from Checkpoint ===")
+        reloaded_model = load_pretrained_meta_clip_model(config)
         checkpoint = torch.load(checkpoint_path, map_location='cpu')
         # The checkpoint is saved directly as model state dict, not wrapped
         reloaded_model.load_state_dict(checkpoint)
@@ -1003,7 +1018,8 @@ def main_meta_clip_post_training_pipeline(config: Dict[str, Any]) -> Tuple[ClipH
     print(f"Model saved to: {config['output_dir']}")
     print(f"Results saved to: {config['results_dir']}")
     
-    return trained_model, history
+    # Return the model actually used for evaluation (reloaded if available).
+    return reloaded_model, history
 
 if __name__ == "__main__":
     import argparse

--- a/models/meta_clip_style_mattress_post_original/README.md
+++ b/models/meta_clip_style_mattress_post_original/README.md
@@ -1,8 +1,8 @@
 ---
-base_model: facebook/metaclip-b16-fullcc2.5b
+base_model: facebook/metaclip-2-worldwide-l14
 library_name: peft
 tags:
-- base_model:adapter:facebook/metaclip-b16-fullcc2.5b
+- base_model:adapter:facebook/metaclip-2-worldwide-l14
 - lora
 - transformers
 ---

--- a/src/demo/model_loaders.py
+++ b/src/demo/model_loaders.py
@@ -51,22 +51,55 @@ def load_model_safely(model, load_path: str, map_location="cpu", strict: bool = 
 
 
 def load_clip_heatmap_model(model_path: str):
-    """Load CLIP heatmap model using the exact same approach as inference_demo_simple.py."""
+    """Load CLIP heatmap model.
+
+    Prefers loading `training_config.json` (or `config.json`) from the model directory so we don't hardcode
+    model_name/image_size/lora settings in multiple places.
+    """
     from src.models.clip_heatmap_model import ClipHeatmapModel
     
     # Try to load from complete model first
     complete_model_path = os.path.join(os.path.dirname(model_path), 'complete_model.pth')
     if os.path.exists(complete_model_path):
         model_path = complete_model_path
+
+    model_dir = os.path.dirname(model_path)
+    cfg = None
+    for cfg_name in ("training_config.json", "config.json"):
+        cfg_path = os.path.join(model_dir, cfg_name)
+        if os.path.exists(cfg_path):
+            try:
+                import json
+                with open(cfg_path, "r") as f:
+                    cfg = json.load(f)
+                break
+            except Exception:
+                cfg = None
     
-    # Create model with exact same config as inference_demo_simple.py
+    # Create model with config from disk (fallback defaults)
+    # Note: MetaCLIP2 L/14 is patch14, so 224 is the safe default image_size.
+    model_name = (cfg or {}).get("model_name", "facebook/metaclip-2-worldwide-l14")
+    image_size = int((cfg or {}).get("image_size", 224))
+    use_lora = bool((cfg or {}).get("use_lora", True))
+    lora_r = int((cfg or {}).get("lora_r", 16))
+    lora_alpha = int((cfg or {}).get("lora_alpha", 32))
+    lora_dropout = float((cfg or {}).get("lora_dropout", 0.05))
+    use_text_prior = bool((cfg or {}).get("use_text_prior", True))
+    prior_prompts = (cfg or {}).get("prior_prompts", None)
+    negative_prompts = (cfg or {}).get("negative_prompts", None)
+    prior_weight = float((cfg or {}).get("prior_weight", 0.5))
+
     model = ClipHeatmapModel(
-        model_name='facebook/metaclip-b16-fullcc2.5b',
-        image_size=256,
-        use_lora=True,
-        lora_r=16,
-        lora_alpha=32,
-        use_text_prior=True
+        model_name=model_name,
+        image_size=image_size,
+        use_lora=use_lora,
+        lora_r=lora_r,
+        lora_alpha=lora_alpha,
+        lora_dropout=lora_dropout,
+        use_text_prior=use_text_prior,
+        prior_prompts=prior_prompts,
+        negative_prompts=negative_prompts,
+        prior_weight=prior_weight,
     )
     
     # Load state dict

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -11,5 +11,5 @@ __all__ = [
     'SingleHeatmapDecoder',
     'ClipHeatmapModel',
     'ClipHeatmapHead',
-    'create_clip_heatmap_model'
+    'create_clip_heatmap_model',
 ]

--- a/src/models/clip_heatmap_model.py
+++ b/src/models/clip_heatmap_model.py
@@ -20,9 +20,9 @@ except ImportError:
     sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
     from src.utils.model_utils import *
 
-# Import CLIP and PEFT dependencies
+# Import (Meta)CLIP and PEFT dependencies
 try:
-    from transformers import CLIPModel, AutoTokenizer
+    from transformers import AutoModel, AutoTokenizer
     HF_AVAILABLE = True
 except ImportError:
     HF_AVAILABLE = False
@@ -116,9 +116,15 @@ class ClipHeatmapModel(nn.Module):
         # Store model name for saving
         self.model_name = model_name
         
-        # Load full CLIP model; we will use its vision submodule directly.
-        clip = CLIPModel.from_pretrained(model_name)
+        # Load full CLIP-like model; MetaCLIP2 checkpoints use `model_type=metaclip_2` and may not
+        # deserialize cleanly via `CLIPModel.from_pretrained`, but they *do* load via `AutoModel`.
+        clip = AutoModel.from_pretrained(model_name)
         self.clip = clip
+        if not hasattr(clip, "vision_model"):
+            raise ValueError(
+                f"Loaded model '{model_name}' does not expose `.vision_model`. "
+                "This training pipeline expects a CLIP-like dual-encoder model."
+            )
         self.vision = clip.vision_model
         self.hidden_size = self.vision.config.hidden_size
         self.patch_size = self.vision.config.patch_size
@@ -166,6 +172,15 @@ class ClipHeatmapModel(nn.Module):
             for p in self.vision.parameters():
                 p.requires_grad = False
 
+        # Guard: ViT patch embedding requires input H/W divisible by patch_size.
+        # Many CLIP-like models are patch16 (256 works), but L/14 models (e.g., MetaCLIP2 L14) require 224/238/252/280... etc.
+        if self.image_size % int(self.patch_size) != 0:
+            raise ValueError(
+                f"image_size={self.image_size} must be divisible by patch_size={self.patch_size} "
+                f"for model_name='{self.model_name}'. "
+                "Tip: for patch14 models use image_size=224; for patch16 models use 256."
+            )
+
     def forward(self, pixel_values: torch.Tensor) -> torch.Tensor:
         """
         Forward pass through the CLIP heatmap model.
@@ -177,6 +192,11 @@ class ClipHeatmapModel(nn.Module):
             Keypoint heatmap (B, 1, image_size, image_size)
         """
         # pixel_values: (B,3,H,W)
+        if (pixel_values.shape[-2] % int(self.patch_size) != 0) or (pixel_values.shape[-1] % int(self.patch_size) != 0):
+            raise ValueError(
+                f"Input tensor HxW={tuple(pixel_values.shape[-2:])} must be divisible by patch_size={self.patch_size} "
+                f"for model_name='{self.model_name}'."
+            )
         # Enable positional embedding interpolation for non-224 inputs
         outputs = self.vision(pixel_values=pixel_values, interpolate_pos_encoding=True)
         tokens = outputs.last_hidden_state  # (B, 1+P, D)

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -19,6 +19,11 @@ from .model_utils import (
 )
 # Quantization utilities removed - functionality deprecated
 
+from .torch_memory import (
+    cleanup_torch_memory,
+    free_torch_memory,
+)
+
 __all__ = [
     # Model utilities
     'YoloBackbone',
@@ -35,5 +40,9 @@ __all__ = [
     'thresholded_locations',
     
     # Losses
-    'kl_heatmap_loss'
+    'kl_heatmap_loss',
+
+    # Memory utils
+    'cleanup_torch_memory',
+    'free_torch_memory',
 ]

--- a/src/utils/tensorrt_utils.py
+++ b/src/utils/tensorrt_utils.py
@@ -138,7 +138,7 @@ class ClipHeatmapModelLoader(ModelLoader):
         
         # Create model
         model = create_clip_heatmap_model(
-            model_name=config.extra_kwargs.get('model_name', 'facebook/metaclip-b16-fullcc2.5b'),
+            model_name=config.extra_kwargs.get('model_name', 'facebook/metaclip-2-worldwide-l14'),
             image_size=config.input_shape[-1],
             use_lora=config.extra_kwargs.get('use_lora', True),
             lora_r=config.extra_kwargs.get('lora_r', 16),
@@ -160,7 +160,7 @@ class ClipHeatmapModelLoader(ModelLoader):
     def get_model_info(self, config: ModelConfig) -> Dict[str, Any]:
         return {
             'model_type': 'ClipHeatmapModel',
-            'model_name': config.extra_kwargs.get('model_name', 'facebook/metaclip-b16-fullcc2.5b'),
+            'model_name': config.extra_kwargs.get('model_name', 'facebook/metaclip-2-worldwide-l14'),
             'use_lora': config.extra_kwargs.get('use_lora', True),
             'input_shape': config.input_shape
         }

--- a/src/utils/torch_memory.py
+++ b/src/utils/torch_memory.py
@@ -1,0 +1,60 @@
+"""
+PyTorch memory helpers.
+
+Why this exists:
+- Some training scripts load a second model for evaluation ("reload from checkpoint")
+  while the trained model is still referenced. That can temporarily hold two full
+  model copies on GPU and trigger OOM.
+"""
+
+from __future__ import annotations
+
+import gc
+from typing import Any
+
+import torch
+
+
+def cleanup_torch_memory() -> None:
+    """
+    Best-effort cleanup of Python + PyTorch allocator state.
+
+    Notes:
+    - This does NOT magically free memory if you still hold references to tensors/models.
+      You must drop references (e.g., `model = None`) before calling this.
+    """
+    gc.collect()
+
+    if torch.cuda.is_available():
+        # Releases cached blocks back to the CUDA caching allocator.
+        torch.cuda.empty_cache()
+        # Helps clean up IPC memory (can matter in some multiprocess / dataloader cases).
+        torch.cuda.ipc_collect()
+
+
+def free_torch_memory(*objs: Any, move_modules_to_cpu: bool = False) -> None:
+    """
+    Best-effort cleanup helper intended to be called right after you drop references.
+
+    Example:
+        trained_model = None
+        optimizer = None
+        free_torch_memory(move_modules_to_cpu=True)
+
+    Args:
+        objs: Optional objects; if `move_modules_to_cpu=True`, any torch.nn.Module-like
+              objects with `.to()` will be moved to CPU before cleanup (best-effort).
+        move_modules_to_cpu: Move modules to CPU to release GPU memory sooner.
+    """
+    if move_modules_to_cpu:
+        for obj in objs:
+            try:
+                if isinstance(obj, torch.nn.Module):
+                    obj.to("cpu")
+            except Exception:
+                # Best-effort only; never fail training because a cleanup attempt failed.
+                pass
+
+    cleanup_torch_memory()
+
+

--- a/tensorrt_convert.py
+++ b/tensorrt_convert.py
@@ -255,7 +255,7 @@ Examples:
     # Model-specific parameters
     parser.add_argument("--use_enhanced_yolo", action="store_true", default=True,
                        help="Use Enhanced YOLO backbone (default: True)")
-    parser.add_argument("--model_name", type=str, default="facebook/metaclip-b16-fullcc2.5b",
+    parser.add_argument("--model_name", type=str, default="facebook/metaclip-2-worldwide-l14",
                        help="CLIP model name (for clip_heatmap_model)")
     parser.add_argument("--use_lora", action="store_true", default=True,
                        help="Use LoRA fine-tuning (for clip_heatmap_model)")
@@ -330,7 +330,7 @@ Examples:
             workspace_size=config.get('workspace_size', 1 << 30),
             benchmark=config.get('benchmark', False),
             use_enhanced_yolo=config.get('use_enhanced_yolo', True),
-            model_name=config.get('model_name', 'facebook/metaclip-b16-fullcc2.5b'),
+            model_name=config.get('model_name', 'facebook/metaclip-2-worldwide-l14'),
             use_lora=config.get('use_lora', True),
             model_variant=config.get('model_variant', 'EfficientKeypointNet')
         )


### PR DESCRIPTION
MetaCLIP → MetaCLIP2 升級/統一預設值
將專案預設 CLIP-like backbone 統一更新為 facebook/metaclip-2-worldwide-l14 同步調整預設 image_size 為 224（配合 L/14 patch=14）
更新推論/載入與 TensorRT 相關 fallback 預設（如 src/demo/model_loaders.py、src/utils/tensorrt_utils.py、tensorrt_convert.py） 避免重載模型時 OOM（釋放舊模型佔用）
新增 src/utils/torch_memory.py：提供 cleanup_torch_memory() / free_torch_memory()（GC + CUDA cache/IP C 回收） 更新 src/utils/__init__.py：匯出記憶體清理工具供專案共用
更新多個 MetaCLIP 訓練腳本（fitted_sheet / fitted_sheet_inverse / bedsheet / mattress）： 在「從 checkpoint 重新載入模型」前先釋放 model/trained_model 等參考並清理 CUDA cache，避免同時駐留兩個模型導致 OOM compare_models_equal_params 改為序列化載入/測試（先測一個→釋放→再測另一個），降低比較模式的記憶體峰值 pipeline 回傳調整為回傳實際用於評估的模型（若有 checkpoint 則回傳 reloaded model）